### PR TITLE
added rudimentary style support to nodes

### DIFF
--- a/dotter/dotter.py
+++ b/dotter/dotter.py
@@ -103,6 +103,23 @@ class Shape:
     Utr = 'utr'
 
 
+class Style:
+
+    """
+    These values can be used as valid node style values.
+    See http://www.graphviz.org/doc/info/shapes.html#d:style for more info.
+
+    """
+    Bold = 'bold'
+    Dashed = 'dashed'
+    Diagonals = 'diagonals'
+    Dotted = 'dotted'
+    Filled = 'filled'
+    Invisible = 'invisible'
+    Rounded = 'rounded'
+    Solid = 'solid'
+
+
 class Dotter:
 
     def __init__(self, directed=True, output_to_file=True,
@@ -171,13 +188,13 @@ class Dotter:
         self.execute(fmt.format(Dotter.escape(node1), Dotter.escape(node2)))
 
     def add_node(self, node, font=None, fontsize=None, label=None, shape=None,
-                 url=None, style=None):
+                 url=None, styles=None):
         self.execute('{0}'.format(Dotter.escape(node)))
         self.set_label(node, label if label else node)
-        self.node_attributes(node, font, fontsize, shape, url, style)
+        self.node_attributes(node, font, fontsize, shape, url, styles)
 
     def node_attributes(self, node, font=None, fontsize=None, shape=None,
-                        url=None, style=None):
+                        url=None, styles=None):
         if font:
             cmd = '{0} [fontname="{1}"]'.format(Dotter.escape(node), font)
             self.execute(cmd)
@@ -190,7 +207,8 @@ class Dotter:
         if url:
             cmd = '{0} [URL="{1}"]'.format(Dotter.escape(node), url)
             self.execute(cmd)
-        if style:
+        if styles:
+            style = ", ".join(styles)
             cmd = '{0} [style="{1}"]'.format(Dotter.escape(node), style)
             self.execute(cmd)
 

--- a/tests/test_dotter.py
+++ b/tests/test_dotter.py
@@ -48,6 +48,18 @@ def test_addnode_label():
     assert expected == dotter.commands
 
 
+def test_addnode_styles():
+    dotter = Dotter()
+    dotter.add_node('a', styles=["diagonals", "filled", "bold"])
+    expected = ['digraph',
+                ' {',
+                'gb',
+                'gb [label="a"]',
+                'gb [style="diagonals, filled, bold"]',
+                ]
+    assert expected == dotter.commands
+
+
 def test_set_position():
     dotter = Dotter(program=Program.Neato)
     dotter.add_node('a')
@@ -87,15 +99,6 @@ def test_output():
     output = output.splitlines()
     expected = load_data('test_output.dot')
     assert output == expected
-
-
-def test_nodes_attributes():
-    dotter = Dotter()
-    dotter.nodes_attributes(shape=Shape.Box)
-    dotter.nodes_attributes(font='MyFont')
-    expected = ['digraph', ' {', 'node [shape="box"]',
-                'node [fontname="MyFont"]']
-    assert dotter.commands == expected
 
 
 def test_output_to_file():


### PR DESCRIPTION
Nothing fancy here... just adding a string passthrough for the style attribute for nodes.

example:

```
dotter.add_node("foo", shape="box", style="diagonals, filled, bold")
```
